### PR TITLE
Print TCP stream throughput separately.

### DIFF
--- a/captcp.py
+++ b/captcp.py
@@ -2316,6 +2316,8 @@ class ThroughputMod(Mod):
                 action="store_true", help="don't create Gnuplot data, just stdio")
         parser.add_option( "-o", "--output-dir", dest="outputdir", default=None,
                 type="string", help="specify the output directory")
+        parser.add_option( "-x", "--separate", dest="separate", default=False,
+                action="store_true", help="print values for the streams separately")
 
 
         self.opts, args = parser.parse_args(sys.argv[0:])
@@ -2332,13 +2334,26 @@ class ThroughputMod(Mod):
         if self.opts.connections:
             self.ids = self.opts.connections.split(',')
             self.logger.info("show limited to the following connections: %s" % (str(self.ids)))
+        else:
+            self.opts.separate = False
 
 
     def output_data(self, time, amount):
         if self.opts.stdio:
-            sys.stdout.write("%5.1f  %10.1f\n" % (time, amount))
+            target = sys.stdout
+            time_format = "%5.1f"
+            amount_format = " %10.1f"
         else:
-            self.throughput_file.write("%.5f %.3f\n" % (time, amount))
+            target = self.throughput_file
+            time_format = "%.5f"
+            amount_format = " %.3f"
+        
+        sys.stdout.write(time_format % time)
+        if self.opts.separate:
+            for data in amount: sys.stdout.write(amount_format % data)
+        else:
+            sys.stdout.write(amount_format % sum(amount))
+        sys.stdout.write("\n")
 
 
     def pre_process_packet(self, ts, packet):
@@ -2369,18 +2384,21 @@ class ThroughputMod(Mod):
         if not self.start_time:
             self.start_time = ts
             self.last_sample = 0.0
-            self.data = 0
+            self.data = [0 for id in self.ids] if self.opts.separate else [0]
             #line += "%.5f" % (Utils.ts_tofloat(time))
 
-        self.data += data_len
+        if self.opts.separate:
+            self.data[self.ids.index(str(sub_connection.connection.connection_id))] += data_len
+        else:
+            self.data[0] += data_len
         self.total_data_len += data_len
 
         timediff = Utils.ts_tofloat(ts - self.start_time)
 
         if timediff > self.last_sample + self.opts.samplelength:
-            amount = U.byte_to_unit(self.data, self.opts.unit)
+            amount = [U.byte_to_unit(data, self.opts.unit) for data in self.data]
             self.output_data(self.last_sample + self.opts.samplelength, amount)
-            self.data  = 0
+            self.data = [0 for id in self.ids] if self.opts.separate else [0]
             self.last_sample += self.opts.samplelength
 
         self.end_time = ts


### PR DESCRIPTION
Adding a command line switch (`-x`, `--separate`) to be able to print TCP stream throughputs separately. The default behaviour doesn't change, it's an addition to the `--flow` switch.

It was very helpful for one of my projects, and I think someone else might use this as well. Please review the patch, and pull it if you like it.
