### PR TITLE
Improve the way connection uid is computed.

### DIFF
--- a/captcp.py
+++ b/captcp.py
@@ -2272,10 +2272,13 @@ class TcpConn:
 
         l = [ord(a) ^ ord(b) for a,b in zip(self.sipnum, self.dipnum)]
 
+        sport = long(self.sport)
+        dport = long(self.dport)
+        portpair = "%04x%04x" % (min(sport, dport), max(sport, dport))
         self.uid = "%s:%s:%s" % (
                 str(self.ipversion),
                 str(l),
-                str(long(self.sport) + long(self.dport)))
+                portpair)
 
         self.iuid = ((self.sipnum) + \
                 (self.dipnum) + ((self.sport) + \


### PR DESCRIPTION
uid is used as an index into the connections hashtable _without_
checking for collisions. The hash function ought to be perfect in this
case, but summing the ports isn't. Additionally, the aim of this hash
function is to generate equal hashes for both subflows of a connection,
ie. it must be the same regardless of the ordering of (dest, src) ports
-- commutative, which summation is.

The new hash function for the port pair consists of ordering, then
concatenating the port numbers. This ensures both a perfect
hash (wrt. to connections, not subflows) and commutativity of the ports.

NB: I haven't changed the way the addresses are hashed, the same problem
applies there.

Proposed fix for #32 