### PR TITLE
Adding Spurious Retransmission Module

### DIFF
--- a/captcp.py
+++ b/captcp.py
@@ -3089,7 +3089,7 @@ class SpuriousRetransmissionsMod(Mod):
                           help="specify the number of the data flow (e.g. 1.1)")
         parser.add_option("-m", "--mode", dest="mode", default="list",
                           type="string",
-                          help="display aggregate summary [aggregate], display"
+                          help="display aggregate summary [summary], display"
                                " all segments which are spurious "
                                "retransmissions [spurious], display all "
                                "segments which are retransmissions "
@@ -3315,7 +3315,7 @@ class SpuriousRetransmissionsMod(Mod):
                              "  source > destination [flags]\n")
             sys.stdout.write(output_str)
 
-        if self.opts.mode == "aggregate":
+        if self.opts.mode == "summary":
             amount_packets = self.amount_packets
             amount_data_packets = len(self.data_packet_list)
             amount_ack_packets = len(self.ack_packet_list)

--- a/captcp.py
+++ b/captcp.py
@@ -3389,7 +3389,7 @@ class SpuriousRetransmissionsMod(Mod):
 
         if self.opts.mode == "retransmissions":
             sys.stdout.write("#   no"
-                             "       time-retr"
+                             "       timestamp"
                              "   time-first"
                              "     time-ack"
                              "  seq-number"

--- a/captcp.py
+++ b/captcp.py
@@ -3334,14 +3334,23 @@ class SpuriousRetransmissionsMod(Mod):
         if self.opts.mode == "list":
             for segment in self.extended_timestamp_list:
                 output_str = str()
+                sorted_retr_list = sorted(retransmission_list)
                 # segment: timestamp, list, index
                 if segment[1] == "data":
                     pos_data = segment[2]
                     packet_no = self.get_abs_packet_no_by_timestamp(segment[0])
                     if packet_no in packet_no_of_spur_retr_list:
                         output_str += (self.color.color_palette["red"])
+                    # note: this blue-white colouring increases the problem
+                    # size by quite a bit
                     elif packet_no in packet_no_of_retr_list:
-                        output_str += (self.color.color_palette["blue"])
+                        for element in sorted_retr_list:
+                            # segment-ts == element-ts
+                            # there should always be a exactly one match here
+                            if segment[0] == element[0]:
+                                # element-ts == first-seq-transmission
+                                if element[0] == element[5]:
+                                    output_str += (self.color.color_palette["blue"])
                     else:
                         output_str += (self.color.color_palette["green"])
                     # packet_no, time, source > dst, len, seq, ack, win, tsval, tsecr

--- a/captcp.py
+++ b/captcp.py
@@ -3351,6 +3351,7 @@ class SpuriousRetransmissionsMod(Mod):
                                 # element-ts == first-seq-transmission
                                 if element[0] == element[5]:
                                     output_str += (self.color.color_palette["blue"])
+                                break
                     else:
                         output_str += (self.color.color_palette["green"])
                     # packet_no, time, source > dst, len, seq, ack, win, tsval, tsecr


### PR DESCRIPTION
also small fine-tuning spacing-data-ack.
Notes:
- module can only analyse dumps of tcp connections, where the timestamp was enabled
- capture files have to be from the sender perspective
- detects: all data (!) retransmissions >= tsval-resolution after original (current Linux: 4ms)
- the module analyses only one tcp flow direction at a time (use sender side file for the opposite flow if it was bi-directional and then aggregate results)


Spurious-Retransmission-Module Modes:
-m summary
    Displays aggregated summary information
-m spurious
    Displays information about every spurious retransmission
-m retransmissions
    Displays information about retransmissions (i added this since i found that wireshark can have problems showing these). Uses colouring: blue is the base transmission (NOT a retransmission, has the same value for timestamp and time-first), white is a regular retransmission. -> #white_entries == #retransmissions (from -m aggregate)
-m list
    Displays a wireshark like connection summary (default mode). Data-packets are green, acks are yellow, retransmissions (as with mode -m) blue for the base, white for every retransmission, spurious-retransmission are red (highest priority). 


Issue with dumpfiles and commands as agreed on will follow.