### PR TITLE
fixed TcpConn uid hashing

### DIFF
--- a/captcp.py
+++ b/captcp.py
@@ -2270,7 +2270,7 @@ class TcpConn:
         self.sipnum = ip.src
         self.dipnum = ip.dst
 
-        l = [ord(a) ^ ord(b) for a,b in zip(self.sipnum, self.dipnum)]
+        l = [(ord(a) << 8) | ord(b) if a > b else (ord(b) << 8) | ord(a) for a,b in zip(self.sipnum, self.dipnum)]
 
         sport = long(self.sport)
         dport = long(self.dport)


### PR DESCRIPTION
The uid hashing for TcpConn class is not unique. For example, it makes the same uid for the the following two ip pairs (10.1.2.1:14000, 10.1.3.2:14000) and (10.1.4.1:14000, 10.1.5.2:14000). This was resulting in the script crashing.

I assumed that the hash function needed to be commutative, as it was originally, thus the extra if. It could have been done in a better way, but this should work